### PR TITLE
Fixed: Resources not in Package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include freidds/resources/*/*

--- a/Manifest.in
+++ b/Manifest.in
@@ -1,0 +1,1 @@
+include freidds/resources/*

--- a/Manifest.in
+++ b/Manifest.in
@@ -1,1 +1,0 @@
-include freidds/resources/*

--- a/freidds/datasets.py
+++ b/freidds/datasets.py
@@ -343,4 +343,3 @@ class COXFaceDB(ReadableMultiLevelDatasetBase):
 
     def _get_v2s_round_camera(self, ids, camera):
         return DatasetBase([s for s in self[camera] if s[1] in ids])
-

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
     packages=['freidds'],
     license='GNU Affero General Public License v3.0',
     long_description=open('README.md').read(),
+    include_package_data=True,
     install_requires=requirements
 )


### PR DESCRIPTION
Upon install with pip, the resources folder was not copied to ```site-packages```.
This was fixed by:
-  including a ```MANIFEST.in``` file with appropriate glob.
- passing ```include_package_data``` as ```True``` in ```setup```.